### PR TITLE
Set-Location should wrap Path parameter with quotes

### DIFF
--- a/src/PowerShell.Tests/Tests/ScriptTests.cs
+++ b/src/PowerShell.Tests/Tests/ScriptTests.cs
@@ -38,7 +38,15 @@ namespace Cake.Powershell.Tests
             Assert.True((results != null) && (results.Count > 0), "Check Rights");
         }
 
+        [Fact]
+        public void Working_Directory_With_Spaces_Should_Properly_Execute()
+        {
+            Collection<PSObject> results = CakeHelper.CreatePowershellRunner().Start("Write-Host",
+                new PowershellSettings().WithArguments(args => args.Append("Testing..."))
+                                        .UseWorkingDirectory(@"C:\Path With Spaces\"));
 
+            Assert.True((DebugLog.Lines != null) && (DebugLog.Lines.Contains("Testing...")), "Output not written to the powershell host");
+        }
 
         /*
         [Fact]

--- a/src/Powershell/Runner/PowershellRunner.cs
+++ b/src/Powershell/Runner/PowershellRunner.cs
@@ -6,6 +6,7 @@
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Diagnostics;
+    using System.Globalization;
     using System.Security.Principal;
 
     using Cake.Core;
@@ -262,7 +263,8 @@ namespace Cake.Powershell
                     //Invoke Command
                     if (settings.WorkingDirectory != null)
                     {
-                        pipeline.Commands.AddScript("Set-Location -Path " + settings.WorkingDirectory.FullPath);
+                        var path = string.Format(CultureInfo.InvariantCulture, "\"{0}\"", settings.WorkingDirectory.FullPath);
+                        pipeline.Commands.AddScript("Set-Location -Path " + path);
                     }
 
                     if ((settings.Modules != null) && (settings.Modules.Count > 0))


### PR DESCRIPTION
When the WorkingDirectory contains spaces, the Set-Location command fails. This is because the Path parameter of the Set-Location command was not properly wrapping the path with quotes. This pull request addresses that issue.