### PR TITLE
Added StringLiteralArgument

### DIFF
--- a/src/Powershell/Arguments/StringLiteralArgument.cs
+++ b/src/Powershell/Arguments/StringLiteralArgument.cs
@@ -1,0 +1,58 @@
+﻿using System.Globalization;
+using Cake.Core.IO;
+
+namespace Cake.Powershell
+{
+    /// <summary>
+    /// Represents a string-literal argument. Specifically,
+    /// '$' chars will not be evaulated as variables, nor will '()' pairs as expressions.
+    /// </summary>
+    public sealed class StringLiteralArgument : IProcessArgument
+    {
+        private readonly IProcessArgument _argument;
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="StringLiteralArgument"/> class.
+        /// </summary>
+        /// <param name="argument">An <see cref="IProcessArgument"/> to wrap as a string-literal.</param>
+        public StringLiteralArgument(IProcessArgument argument)
+        {
+            _argument = argument;
+        }
+
+        /// <summary>
+        /// Renders the argument as a string-literal <see cref="string"/>.
+        /// </summary>
+        /// <returns>A string-literal represenation of the argument.</returns>
+        public string Render()
+        {
+            return MakePowershellLiteralString(_argument.Render());
+        }
+
+        /// <summary>
+        /// Renders the argument as a string-literal <see cref="string"/>.
+        /// Sensitive information will be redacted.
+        /// </summary>
+        /// <returns>A safe string representation of the argument.</returns>
+        public string RenderSafe()
+        {
+            return MakePowershellLiteralString(_argument.RenderSafe());
+        }
+
+        /// <summary>
+        /// Returns a <see cref="string" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return RenderSafe();
+        }
+
+        private static string MakePowershellLiteralString(string text)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "'{0}'", text.Replace("'", "''"));
+        }
+    }
+}

--- a/src/Powershell/Cake.Powershell.csproj
+++ b/src/Powershell/Cake.Powershell.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="Aliases\PowershellAliases.cs" />
     <Compile Include="Arguments\NamedArgument.cs" />
+    <Compile Include="Arguments\StringLiteralArgument.cs" />
     <Compile Include="Extensions\PowershellSettingsExtensions.cs" />
     <Compile Include="Extensions\ProcessArgumentListExtensions.cs" />
     <Compile Include="Extensions\SecureExtensions.cs" />

--- a/src/Powershell/Extensions/ProcessArgumentListExtensions.cs
+++ b/src/Powershell/Extensions/ProcessArgumentListExtensions.cs
@@ -99,7 +99,34 @@ namespace Cake.Powershell
             return builder;
         }
 
+        /// <summary>
+        /// Appends the specified text as a string-literal to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The argument name.</param>
+        /// <param name="text">The text to be quoted and appended as a string-literal.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendStringLiteral(this ProcessArgumentBuilder builder, string name, string text)
+        {
+            return AppendStringLiteral(builder, name, new TextArgument(text));
+        }
 
+        /// <summary>
+        /// Appends the specified argument as a string-literal to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The argument name.</param>
+        /// <param name="argument">The argument to be quoted and appended as a string-literal.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendStringLiteral(this ProcessArgumentBuilder builder, string name, IProcessArgument argument)
+        {
+            if (builder != null)
+            {
+                builder.Append(new NamedArgument(name, new StringLiteralArgument(argument)));
+            }
+
+            return builder;
+        }
 
         /// <summary>
         /// Appends the specified secret text to the argument builder.
@@ -152,8 +179,6 @@ namespace Cake.Powershell
             return builder;
         }
 
-
-
         /// <summary>
         /// Quotes and appends the specified secret text to the argument builder.
         /// </summary>
@@ -201,6 +226,34 @@ namespace Cake.Powershell
             if (builder != null)
             {
                 builder.Append(new NamedArgument(name, new QuotedArgument(new SecretArgument(argument)), format));
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Appends the specified secret text as a string-literal to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The argument name.</param>
+        /// <param name="text">The secret text to be appended.</param>
+        public static ProcessArgumentBuilder AppendStringLiteralSecret(this ProcessArgumentBuilder builder, string name, string text)
+        {
+            return AppendStringLiteralSecret(builder, name, new TextArgument(text));
+        }
+
+        /// <summary>
+        /// Appends the specified secret argument as a string-literal to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The argument name.</param>
+        /// <param name="argument">The secret argument to be appended.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendStringLiteralSecret(this ProcessArgumentBuilder builder, string name, IProcessArgument argument)
+        {
+            if (builder != null)
+            {
+                builder.Append(new NamedArgument(name, new StringLiteralArgument(new SecretArgument(argument))));
             }
 
             return builder;


### PR DESCRIPTION
$ chars will not be considered variables for expansion, nor will '()' pairs be considered expressions.