### PR TITLE
Provide setting to not output to the console

### DIFF
--- a/src/Powershell/Cake.Powershell.csproj
+++ b/src/Powershell/Cake.Powershell.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Extensions\SecureExtensions.cs" />
     <Compile Include="Host\CakePSHost.cs" />
     <Compile Include="Host\CakePSHostInterface.cs" />
+    <Compile Include="Host\CakePSHostNoConsoleRawUserInterface.cs" />
     <Compile Include="Host\CakePSHostRawUserInterface.cs" />
     <Compile Include="Interfaces\IPowershellRunner.cs" />
     <Compile Include="Runner\PowershellRunner.cs" />

--- a/src/Powershell/Extensions/PowershellSettingsExtensions.cs
+++ b/src/Powershell/Extensions/PowershellSettingsExtensions.cs
@@ -221,5 +221,22 @@ namespace Cake.Powershell
             settings.LogOutput = log;
             return settings;
         }
+
+        /// <summary>
+        /// Sets a value indicating whether the output of an application is written to its on-screen console.
+        /// </summary>
+        /// <param name="settings">The powershell settings.</param>
+        /// <param name="outputToAppConsole">true if output should be written to the app's on-screen console; otherwsie, false. The default is true.</param>
+        /// <returns>The same <see cref="PowershellSettings"/> instance so that multiple calls can be chained.</returns>
+        public static PowershellSettings OutputToAppConsole(this PowershellSettings settings, bool outputToAppConsole = true)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            settings.OutputToAppConsole = outputToAppConsole;
+            return settings;
+        }
     }
 }

--- a/src/Powershell/Host/CakePSHost.cs
+++ b/src/Powershell/Host/CakePSHost.cs
@@ -24,14 +24,14 @@ namespace Cake.Powershell
 
 
         #region Constructor (1)
-            internal CakePSHost(ICakeLog log)
+            internal CakePSHost(ICakeLog log, bool outputToAppConsole)
             {
                 if (log == null)
                 {
                     throw new ArgumentNullException("log");
                 }
 
-                _Interface = new CakePSHostInterface(log);
+                _Interface = new CakePSHostInterface(log, outputToAppConsole);
             }
         #endregion
 

--- a/src/Powershell/Host/CakePSHostInterface.cs
+++ b/src/Powershell/Host/CakePSHostInterface.cs
@@ -1,6 +1,5 @@
 ﻿#region Using Statements
     using System;
-    using System.Text;
     using System.Collections.Generic;
 
     using System.Management.Automation;
@@ -25,7 +24,7 @@ namespace Cake.Powershell
 
 
         #region Constructor (1)
-            internal CakePSHostInterface(ICakeLog log)
+            internal CakePSHostInterface(ICakeLog log, bool outputToAppConsole)
             {
                 if (log == null)
                 {
@@ -33,7 +32,9 @@ namespace Cake.Powershell
                 }
 
                 _Log = log;
-                _RawUI = new CakePSHostRawUserInterface(_Log);
+                _RawUI = outputToAppConsole
+                    ? new CakePSHostRawUserInterface(_Log)
+                    : (PSHostRawUserInterface) new CakePSHostNoConsoleRawUserInterface();
             }
         #endregion
 

--- a/src/Powershell/Host/CakePSHostNoConsoleRawUserInterface.cs
+++ b/src/Powershell/Host/CakePSHostNoConsoleRawUserInterface.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Management.Automation.Host;
+
+namespace Cake.Powershell
+{
+    /// <summary>
+    /// An implementation of <see cref="PSHostRawUserInterface"/> that is used when an app has no console for output.
+    /// </summary>
+    /// <seealso cref="PSHostRawUserInterface" />
+    internal sealed class CakePSHostNoConsoleRawUserInterface : PSHostRawUserInterface
+    {
+        /// <summary>
+        /// There is no console, so a ConsoleColor of black is returned.
+        /// </summary>
+        public override ConsoleColor BackgroundColor
+        {
+            get
+            {
+                return ConsoleColor.Black;
+            }
+            set
+            {
+            }
+        }
+
+        /// <summary>
+        /// There is no console, so buffer size of 300x5000 is returned to prevent crashes.
+        /// </summary>
+        public override Size BufferSize
+        {
+            get
+            {
+                return new Size(300, 5000);
+            }
+            set
+            {
+            }
+        }
+
+        /// <summary>
+        /// There is no console, so an empty Coordinates instance is returned.
+        /// </summary>
+        public override Coordinates CursorPosition
+        {
+            get
+            {
+                return new Coordinates();
+            }
+            set
+            {
+            }
+        }
+
+        /// <summary>
+        /// There is no console, so a cursor size of 1 is returned.
+        /// </summary>
+        public override int CursorSize
+        {
+            get
+            {
+                return 1;
+            }
+            set
+            {
+            }
+        }
+
+        /// <summary>
+        /// There is no console, so a ConsoleColor of white is returned.
+        /// </summary>
+        public override ConsoleColor ForegroundColor
+        {
+            get
+            {
+                return ConsoleColor.White;
+            }
+            set
+            {
+            }
+        }
+
+        /// <summary>
+        /// There is no color, so false is returned to indicate no key was pressed.
+        /// </summary>
+        public override bool KeyAvailable
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// There is no console, so the value of <see cref="BufferSize"/> is returned.
+        /// </summary>
+        public override Size MaxPhysicalWindowSize
+        {
+            get
+            {
+                return BufferSize;
+            }
+        }
+
+
+        /// <summary>
+        /// There is no console, so the value of <see cref="BufferSize"/> is returned.
+        /// </summary>
+        public override Size MaxWindowSize
+        {
+            get
+            {
+                return BufferSize;
+            }
+        }
+
+        /// <summary>
+        /// There is no console, so empty Coordinates are returned.
+        /// </summary>
+        public override Coordinates WindowPosition
+        {
+            get
+            {
+                return new Coordinates();
+            }
+            set
+            {
+            }
+        }
+
+        /// <summary>
+        /// There is no console, so the value of <see cref="BufferSize"/> is returned.
+        /// </summary>
+        public override Size WindowSize
+        {
+            get
+            {
+                return BufferSize;
+            }
+            set
+            {
+            }
+        }
+
+        /// <summary>
+        /// There is no console, so an empty string is returned.
+        /// </summary>
+        public override string WindowTitle
+        {
+            get
+            {
+                return string.Empty;
+            }
+            set
+            {
+            }
+        }
+
+        /// <summary>
+        /// There is no console, so this is not implemented.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <exception cref="NotImplementedException"></exception>
+        public override KeyInfo ReadKey(ReadKeyOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// There is no console, so this is not implemented.
+        /// </summary>
+        /// <param name="rectangle">The rectangle.</param>
+        /// <exception cref="NotImplementedException"></exception>
+        public override BufferCell[,] GetBufferContents(Rectangle rectangle)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// There is no console, does nothing
+        /// </summary>
+        public override void FlushInputBuffer()
+        {
+        }
+
+        /// <summary>
+        /// There is no console, does nothing
+        /// </summary>
+        public override void SetBufferContents(Coordinates origin, BufferCell[,] contents)
+        {
+        }
+
+        /// <summary>
+        /// There is no console, does nothing
+        /// </summary>
+        public override void SetBufferContents(Rectangle rectangle, BufferCell fill)
+        {
+        }
+
+        /// <summary>
+        /// There is no console, does nothing
+        /// </summary>
+        public override void ScrollBufferContents(Rectangle source, Coordinates destination, Rectangle clip, BufferCell fill)
+        {
+        }
+    }
+}

--- a/src/Powershell/Runner/PowershellRunner.cs
+++ b/src/Powershell/Runner/PowershellRunner.cs
@@ -219,7 +219,7 @@ namespace Cake.Powershell
                 if (String.IsNullOrEmpty(settings.ComputerName))
                 {
                     //Local
-                    runspace = RunspaceFactory.CreateRunspace(new CakePSHost(_Log));
+                    runspace = RunspaceFactory.CreateRunspace(new CakePSHost(_Log, settings.OutputToAppConsole));
                 }
                 else
                 {
@@ -248,7 +248,7 @@ namespace Cake.Powershell
                         connection.OpenTimeout = settings.Timeout.Value;
                     }
 
-                    runspace = RunspaceFactory.CreateRunspace(new CakePSHost(_Log), connection);
+                    runspace = RunspaceFactory.CreateRunspace(new CakePSHost(_Log, settings.OutputToAppConsole), connection);
                 }
 
                 runspace.Open();

--- a/src/Powershell/Runner/PowershellSettings.cs
+++ b/src/Powershell/Runner/PowershellSettings.cs
@@ -21,8 +21,9 @@ namespace Cake.Powershell
             /// </summary>
             public PowershellSettings()
             {
-                this.FormatOutput = false;
-                this.LogOutput = false;
+                FormatOutput = false;
+                LogOutput = false;
+                OutputToAppConsole = true;
             }
         #endregion
 
@@ -77,7 +78,10 @@ namespace Cake.Powershell
             /// </summary>
             public bool LogOutput { get; set; }
 
-
+            /// <summary>
+            /// If the host should output to the app's console
+            /// </summary>
+            public bool OutputToAppConsole { get; set; }
 
             /// <summary>
             /// Gets or sets the modules to load into the initial state


### PR DESCRIPTION
@SharpeRAD, sorry it's me again.

We encountered a scenario where scripts will fail when run under TeamCity because its cake/powershell runner does not have a console. In other words, Powershell will try to retrieve info from System.Console, but there is no window handle so an exception is thrown:

```shell
---> System.IO.IOException: The handle is invalid.
  at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
  at System.Console.GetBufferInfo(Boolean throwOnNoConsole, Boolean& succeeded)
  at Cake.Powershell.CakePSHostRawUserInterface.get_BufferSize()
  at System.Management.Automation.Internal.Host.InternalHostRawUserInterface.get_BufferSize()
  at Microsoft.PowerShell.Commands.OutStringCommand.InstantiateLineOutputInterface()
  at Microsoft.PowerShell.Commands.OutStringCommand.BeginProcessing()
  at System.Management.Automation.Cmdlet.DoBeginProcessing()
  at System.Management.Automation.CommandProcessorBase.DoBegin()
  --- End of inner exception stack trace ---
  at System.Management.Automation.Runspaces.PipelineBase.Invoke(IEnumerable input)
  at Cake.Powershell.PowershellRunner.Invoke(String script, PowershellSettings settings)
  at Submission#0.StartPowershellFile(FilePath path, PowershellSettings settings)
  at Submission#0.ExecutePowershellScriptFile(String scriptFileName, IList`1 arguments)
```

Admittedly, I don't know much about Managed Powershell; although this workaround fixed our issue, any suggestions for a cleaner solution are welcome.