### PR TITLE
Added ArrayArgument

### DIFF
--- a/src/Powershell/Arguments/ArrayArgument.cs
+++ b/src/Powershell/Arguments/ArrayArgument.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Cake.Core.IO;
+
+namespace Cake.Powershell
+{
+    /// <summary>
+    /// Represents a comma separated array of arguments.
+    /// </summary>
+    public sealed class ArrayArgument : IProcessArgument
+    {
+        private const string ArgumentSeparator = ", ";
+
+        private readonly IEnumerable<IProcessArgument> _arguments;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArrayArgument"/> class.
+        /// </summary>
+        /// <param name="arguments">The arguments that will be comma separated.</param>
+        public ArrayArgument(IEnumerable<IProcessArgument> arguments)
+        {
+            _arguments = arguments;
+        }
+
+        /// <summary>
+        /// Render the arguments as a <see cref="T:System.String" />.
+        /// Sensitive information will be included.
+        /// </summary>
+        /// <returns>
+        /// A comma separated string representation of the arguments.
+        /// </returns>
+        public string Render()
+        {
+            return ConcatenateStrings(_arguments.Select(argument => argument.Render()));
+        }
+
+        /// <summary>
+        /// Renders the argument as a <see cref="T:System.String" />.
+        /// Sensitive information will be redacted.
+        /// </summary>
+        /// <returns>
+        /// A comma separated safe string representation of the argument.
+        /// </returns>
+        public string RenderSafe()
+        {
+            return ConcatenateStrings(_arguments.Select(argument => argument.RenderSafe()));
+        }
+
+        private static string ConcatenateStrings(IEnumerable<string> strings)
+        {
+            return string.Join(ArgumentSeparator, strings);
+        }
+    }
+}

--- a/src/Powershell/Cake.Powershell.csproj
+++ b/src/Powershell/Cake.Powershell.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Aliases\PowershellAliases.cs" />
+    <Compile Include="Arguments\ArrayArgument.cs" />
     <Compile Include="Arguments\NamedArgument.cs" />
     <Compile Include="Arguments\StringLiteralArgument.cs" />
     <Compile Include="Extensions\PowershellSettingsExtensions.cs" />

--- a/src/Powershell/Extensions/ProcessArgumentListExtensions.cs
+++ b/src/Powershell/Extensions/ProcessArgumentListExtensions.cs
@@ -1,6 +1,10 @@
 ﻿#region Using Statements
-    using Cake.Core.IO;
-    using Cake.Core.IO.Arguments;
+
+using System.Collections.Generic;
+using System.Linq;
+using Cake.Core.IO;
+using Cake.Core.IO.Arguments;
+
 #endregion
 
 
@@ -123,6 +127,40 @@ namespace Cake.Powershell
             if (builder != null)
             {
                 builder.Append(new NamedArgument(name, new StringLiteralArgument(argument)));
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Appends the specified arguments as an array to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The argument name.</param>
+        /// <param name="arguments">The text collection to be appended as an array.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendArray(this ProcessArgumentBuilder builder, string name, IEnumerable<string> arguments)
+        {
+            if (builder != null)
+            {
+                builder.Append(new NamedArgument(name, new ArrayArgument(arguments.Select(argument => new TextArgument(argument)))));
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Appends the specified arguments as an array to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The argument name.</param>
+        /// <param name="arguments">The arguments to be appended as an array.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendArray(this ProcessArgumentBuilder builder, string name, IEnumerable<IProcessArgument> arguments)
+        {
+            if (builder != null)
+            {
+                builder.Append(new NamedArgument(name, new ArrayArgument(arguments)));
             }
 
             return builder;
@@ -254,6 +292,40 @@ namespace Cake.Powershell
             if (builder != null)
             {
                 builder.Append(new NamedArgument(name, new StringLiteralArgument(new SecretArgument(argument))));
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Appends the specified arguments as an array to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The argument name.</param>
+        /// <param name="arguments">The arguments to be appended as an array.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendSecretArray(this ProcessArgumentBuilder builder, string name, IEnumerable<string> arguments)
+        {
+            if (builder != null)
+            {
+                builder.Append(new NamedArgument(name, new ArrayArgument(arguments.Select(argument => new TextArgument(argument)))));
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Appends the specified secret arguments as an array to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The argument name.</param>
+        /// <param name="arguments">The secret arguments to be appended as an array.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendSecretArray(this ProcessArgumentBuilder builder, string name, IEnumerable<IProcessArgument> arguments)
+        {
+            if (builder != null)
+            {
+                builder.Append(new NamedArgument(name, new ArrayArgument(arguments.Select(argument => new SecretArgument(argument)))));
             }
 
             return builder;


### PR DESCRIPTION
Use this for Powershell parameters that expect an array of values.

Heya @SharpeRAD, we added `ArrayArgument` to support scenarios where a paramter can accept an array of values. For example:
```powershell
Enter-PSSession -ComputerName comp1, comp2, comp3
```