### PR TITLE
Add extra brace escaping to logging logic

### DIFF
--- a/src/Powershell/Runner/PowershellRunner.cs
+++ b/src/Powershell/Runner/PowershellRunner.cs
@@ -85,7 +85,7 @@ namespace Cake.Powershell
                 //Get Script
                 this.SetWorkingDirectory(settings);
 
-                _Log.Debug(Verbosity.Normal, String.Format("Executing: {0}", this.AppendArguments(script, settings.Arguments, true)));
+                LogExecutingCommand(settings, script);
 
 
 
@@ -118,7 +118,7 @@ namespace Cake.Powershell
                 this.SetWorkingDirectory(settings);
                 string script = "&\"" + path.MakeAbsolute(settings.WorkingDirectory).FullPath + "\"";
 
-                _Log.Debug(Verbosity.Normal, String.Format("Executing: {0}", this.AppendArguments(script, settings.Arguments, true)));
+                LogExecutingCommand(settings, script);
 
 
 
@@ -160,7 +160,7 @@ namespace Cake.Powershell
                 WebClient client = new WebClient();
                 client.DownloadFile(uri, fullPath);
 
-                _Log.Debug(Verbosity.Normal, String.Format("Executing: {0}", this.AppendArguments(script, settings.Arguments, true)));
+                LogExecutingCommand(settings, script);
 
 
 
@@ -172,7 +172,7 @@ namespace Cake.Powershell
 
 
 
-            //Helpers
+        //Helpers
             private void SetWorkingDirectory(PowershellSettings settings)
             {
                 if (String.IsNullOrEmpty(settings.ComputerName))
@@ -209,6 +209,13 @@ namespace Cake.Powershell
                 }
 
                 return script;
+            }
+
+            private void LogExecutingCommand(PowershellSettings settings, string script, bool safe = true)
+            {
+                _Log.Debug(Verbosity.Normal,
+                    String.Format("Executing: {0}",
+                        this.AppendArguments(script, settings.Arguments, safe).Replace("{", "{{").Replace("}", "}}")));
             }
 
             private Collection<PSObject> Invoke(string script, PowershellSettings settings)


### PR DESCRIPTION
As discussed, resolves #7 

I refactored that line out into a common method to make it clearer, hope you don't mind.

---

Using cake.exe's built-in log, it actually results in log output like the following:
```
Executing: Invoke-Command -ScriptBlock {{ c:\TEMP\test.ps1 -name name -password test }}
```

but from what I can tell with the default logger, there is no way to output only a single brace, so this is safer, and won't break `string.Format`-based loggers either :) 