### PR TITLE
#13 - Immediate Powershell Output

### DIFF
--- a/src/PowerShell.Tests/Tests/FileTests.cs
+++ b/src/PowerShell.Tests/Tests/FileTests.cs
@@ -1,16 +1,8 @@
 ﻿#region Using Statements
-    using System;
-    using System.IO;
-    using System.Collections.ObjectModel;
-
-    using Xunit;
-
-    using System.Management.Automation;
-    using System.Management.Automation.Runspaces;
-
-    using Cake.Core.Diagnostics;
-    using Cake.Core.IO;
-    using Cake.Powershell;
+using Cake.Core.IO;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using Xunit;
 #endregion
 
 
@@ -36,7 +28,7 @@ namespace Cake.Powershell.Tests
             Collection<PSObject> results = CakeHelper.CreatePowershellRunner().Start(new FilePath("../../Scripts/Test.ps1"),
                 new PowershellSettings().WithArguments(args => args.Append("Service", "eventlog")));
 
-            Assert.True((results != null) && (results.Count == 1), "Check Rights");
+            Assert.True((results != null) && (results.Count >= 1), "Check Rights");
         }
 
 


### PR DESCRIPTION
Take #2 - now with passing unit tests. 

Immediately stream output from the Powershell script to the cake build script.