### PR TITLE
Upgrading to Cake.Core 0.22. Target .NET 4.6.1 framework

### DIFF
--- a/src/PowerShell.Tests/Cake.Powershell.Tests.csproj
+++ b/src/PowerShell.Tests/Cake.Powershell.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.Powershell.Tests</RootNamespace>
     <AssemblyName>Cake.Powershell.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,9 +39,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Cake.Core, Version=0.22.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.22.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>

--- a/src/PowerShell.Tests/packages.config
+++ b/src/PowerShell.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.22.0" targetFramework="net461" />
   <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.0.0" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/src/Powershell/Cake.Powershell.csproj
+++ b/src/Powershell/Cake.Powershell.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.Powershell</RootNamespace>
     <AssemblyName>Cake.Powershell</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -33,9 +33,8 @@
     <DocumentationFile>bin\Release\Cake.Powershell.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Cake.Core, Version=0.22.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.22.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Powershell/packages.config
+++ b/src/Powershell/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.22.0" targetFramework="net461" />
   <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I noticed the following from our build output. Our specific issue was due to our build.ps1 script still targeting 0.17.0 version of Cake, so upgrading to the latest build.ps1 fixed our issues. However, it seems likely this upgrade is forthcoming:

```
Error: The assembly 'Cake.Powershell, Version=0.3.5.0, Culture=neutral, PublicKeyToken=null' 
is referencing an older version of Cake.Core (0.17.0). 
This assembly need to reference at least Cake.Core version 0.22.0. 
Another option is to downgrade Cake to an earlier version. 
It's not recommended, but you can explicitly opt-out of assembly verification 
by configuring the Skip Verification setting to true
(i.e. command line parameter "--settings_skipverification=true", 
envrionment variable "CAKE_SETTINGS_SKIPVERIFICATION=true", 
read more about configuration at https://cakebuild.net/docs/fundamentals/configuration)``
```