### PR TITLE
Changes to allow scripts to be executed with dot sourcing

### DIFF
--- a/src/Cake.Powershell.Tests/Tests/FileTests.cs
+++ b/src/Cake.Powershell.Tests/Tests/FileTests.cs
@@ -35,6 +35,15 @@ namespace Cake.Powershell.Tests
         }
 
         [Fact]
+        public void Start_File_With_Dot_Sourcing()
+        {
+            Collection<PSObject> results = CakeHelper.CreatePowershellRunner().Start(new FilePath("Scripts/Test.ps1"),
+                new PowershellSettings().WithDotSourcing());
+
+            Assert.True((results != null) && (results.Count >= 1), "Check Rights");
+        }
+
+        [Fact]
         public void Exception_Script_Should_Throw_Exception()
         {
             var runner = CakeHelper.CreatePowershellRunner();

--- a/src/Cake.Powershell/Extensions/PowershellSettingsExtensions.cs
+++ b/src/Cake.Powershell/Extensions/PowershellSettingsExtensions.cs
@@ -68,6 +68,23 @@ namespace Cake.Powershell
         }
 
 
+        /// <summary>
+        /// Executes scripts using dot sourcing
+        /// </summary>
+        /// <param name="settings">The powershell settings.</param>
+        /// <returns>The same <see cref="PowershellSettings"/> instance so that multiple calls can be chained.</returns>
+        public static PowershellSettings WithDotSourcing(this PowershellSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            settings.UseDotSourcing = true;
+            return settings;
+        }
+
+
 
         /// <summary>
         /// Sets the working directory for the process to be started.

--- a/src/Cake.Powershell/Runner/PowershellRunner.cs
+++ b/src/Cake.Powershell/Runner/PowershellRunner.cs
@@ -84,7 +84,9 @@ namespace Cake.Powershell
             //Get Script
             this.SetWorkingDirectory(settings);
 
-            LogExecutingCommand(settings, script);
+            string prefix = settings.UseDotSourcing ? ". " : "";
+
+            LogExecutingCommand(settings, prefix + script);
 
 
 
@@ -115,7 +117,10 @@ namespace Cake.Powershell
 
             //Get Script
             this.SetWorkingDirectory(settings);
-            string script = "&\"" + path.MakeAbsolute(settings.WorkingDirectory).FullPath + "\"";
+
+            string prefix = settings.UseDotSourcing ? ". " : "&";
+            string fullPath = path.MakeAbsolute(settings.WorkingDirectory).FullPath;
+            string script = prefix + "\"" + fullPath + "\"";
 
             LogExecutingCommand(settings, script);
 
@@ -150,8 +155,9 @@ namespace Cake.Powershell
             //Get Script
             this.SetWorkingDirectory(settings);
 
+            string prefix = settings.UseDotSourcing ? ". " : "&";
             string fullPath = path.MakeAbsolute(settings.WorkingDirectory).FullPath;
-            string script = "&\"" + path.MakeAbsolute(settings.WorkingDirectory).FullPath + "\"";
+            string script = prefix + "\"" + fullPath + "\"";
 
 
 
@@ -279,6 +285,11 @@ namespace Cake.Powershell
                     settings.Modules.ToList().ForEach(m => pipeline.Commands.AddScript("Import-Module " + m));
                 }
 
+                //if (settings.UseGlobalScope)
+                //{
+                //    script = $". {script}";
+                //}
+                //pipeline.Commands.AddScript(script, !settings.UseGlobalScope);
                 pipeline.Commands.AddScript(script);
 
                 if (settings.FormatOutput)

--- a/src/Cake.Powershell/Runner/PowershellSettings.cs
+++ b/src/Cake.Powershell/Runner/PowershellSettings.cs
@@ -91,6 +91,12 @@ namespace Cake.Powershell
         /// </summary>
         /// <value>The set of command-line arguments to use when starting the application.</value>
         public ProcessArgumentBuilder Arguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating to use dot sourcing when executing scripts.
+        /// </summary>
+        /// <value><c>true</c> if dot sourcing should be used; otherwise <c>false</c>.</value>
+        public bool UseDotSourcing { get; set; }
         #endregion
     }
 }

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -5,8 +5,8 @@
 //------------------------------------------------------------------------------
 using System.Reflection;
 
-[assembly: AssemblyVersion("0.4.1")]
-[assembly: AssemblyFileVersion("0.4.1")]
-[assembly: AssemblyInformationalVersion("0.4.1")]
+[assembly: AssemblyVersion("0.4.2")]
+[assembly: AssemblyFileVersion("0.4.2")]
+[assembly: AssemblyInformationalVersion("0.4.2")]
 [assembly: AssemblyCopyright("Copyright (c) 2015 - 2017 Phillip Sharpe")]
 


### PR DESCRIPTION
I am working on a ServiceFabric project and wanted to deploy my micro services using the Deploy-FabricApplication.ps1 powershell script. However this script only works correctly if it is run using dot sourcing (. ./Deploy-FabricApplication.ps1). So I have made changes to allow Cake.Powershell to run scripts using dot sourcing. It appears to work as intended and I am now building and deploying my services using a cake script which references a custom build of the Cake.Powershell.dll.

I am submitting the changes back to you in case they are useful enough to be included in the main project.