### PR TITLE
GH-49: Expose AuthenticationMechanism in PowershellSettings

### DIFF
--- a/src/Cake.Powershell/Extensions/PowershellSettingsExtensions.cs
+++ b/src/Cake.Powershell/Extensions/PowershellSettingsExtensions.cs
@@ -1,7 +1,7 @@
 ﻿#region Using Statements
 using System;
 using System.Collections.Generic;
-
+using System.Management.Automation.Runspaces;
 using Cake.Core.IO;
 #endregion
 
@@ -199,6 +199,23 @@ namespace Cake.Powershell
             }
 
             settings.Password = password;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the authentication mechanism to use when connecting
+        /// </summary>
+        /// <param name="settings">The powershell settings.</param>
+        /// <param name="authenticationMechanism">The authentication mechanism to connect with.</param>
+        /// <returns>The same <see cref="PowershellSettings"/> instance so that multiple calls can be chained.</returns>
+        public static PowershellSettings UseAuthenticationMechanism(this PowershellSettings settings, AuthenticationMechanism authenticationMechanism)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            settings.AuthenticationMechanism = authenticationMechanism;
             return settings;
         }
 

--- a/src/Cake.Powershell/Runner/PowershellRunner.cs
+++ b/src/Cake.Powershell/Runner/PowershellRunner.cs
@@ -254,6 +254,7 @@ namespace Cake.Powershell
                 if (!String.IsNullOrEmpty(settings.Username))
                 {
                     connection.Credential = new PSCredential(settings.Username, settings.Password.MakeSecure());
+                    connection.AuthenticationMechanism = settings.AuthenticationMechanism;
                 }
 
                 if (settings.Timeout.HasValue)

--- a/src/Cake.Powershell/Runner/PowershellSettings.cs
+++ b/src/Cake.Powershell/Runner/PowershellSettings.cs
@@ -1,6 +1,6 @@
 ﻿#region Using Statements
 using System.Collections.Generic;
-
+using System.Management.Automation.Runspaces;
 using Cake.Core.IO;
 #endregion
 
@@ -64,6 +64,11 @@ namespace Cake.Powershell
         /// Gets or sets the credentials to use when connecting
         /// </summary>
         public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the authentication mechanism to use when conecting
+        /// </summary>
+        public AuthenticationMechanism AuthenticationMechanism { get; set; }
 
 
 


### PR DESCRIPTION
Expose AuthenticationMechanism in PowershellSettings and update runner to honor that setting

The PowershellSettings class now exposes an AuthenticationMechanism property.  The PowershellSettingsExtensions class also has been updated to offer an extension method to set this property.  Finally, the PowershellRunner class has been updated to apply the value of this new property to the connection when a username is specified.