### PR TITLE
Adding support for passing HashTable arguments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ src/TestResults/
 Thumbs.db
 
 src/*/wwwroot/version.txt
+/.vs/slnx.sqlite
+/.vs/ProjectSettings.json

--- a/src/Cake.Powershell.Tests/Scripts/ArrayTest.ps1
+++ b/src/Cake.Powershell.Tests/Scripts/ArrayTest.ps1
@@ -1,0 +1,16 @@
+﻿param 
+(                      
+	[array] $AnArray = @()                     
+)
+
+if ($AnArray.Length -eq 0)
+{
+	"Array is Empty"
+}
+else
+{
+    foreach($item in $AnArray)
+    {
+        $item
+    }
+}

--- a/src/Cake.Powershell.Tests/Scripts/HashTableTest.ps1
+++ b/src/Cake.Powershell.Tests/Scripts/HashTableTest.ps1
@@ -1,0 +1,9 @@
+﻿param 
+(                      
+	[hashtable]$AHashTable = @{}                     
+)
+
+foreach($kvp in $AHashTable.GetEnumerator())
+{
+    $kvp.Key + " = " + $kvp.Value
+}

--- a/src/Cake.Powershell.Tests/Tests/FileTests.cs
+++ b/src/Cake.Powershell.Tests/Tests/FileTests.cs
@@ -1,6 +1,7 @@
 ﻿#region Using Statements
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
@@ -32,6 +33,44 @@ namespace Cake.Powershell.Tests
                 new PowershellSettings().WithArguments(args => args.Append("Service", "eventlog")));
 
             Assert.True((results != null) && (results.Count >= 1), "Check Rights");
+        }
+
+        [Fact]
+        public void Start_File_With_ArrayParameters()
+        {
+            var array = new string[] {"A", "B", "C"};
+
+            Collection<PSObject> results = CakeHelper.CreatePowershellRunner().Start(new FilePath("Scripts/ArrayTest.ps1"),
+                new PowershellSettings().WithArguments(args => args.AppendArray("AnArray", array)));
+
+            Assert.True((results != null) && (results.Count == array.Length + 1));
+            Assert.Equal("0", results[0].BaseObject.ToString());
+
+            foreach (var item in array)
+            {
+                Assert.True(results.Any(r => r.BaseObject.ToString().Equals((item))));
+            }
+        }
+
+        [Fact]
+        public void Start_File_With_HashTableParameters()
+        {
+            var dict = new Dictionary<string, string>
+            {
+                { "A", "1" },
+                { "B", "2 "},
+                { "C", "3" }
+            };
+            Collection<PSObject> results = CakeHelper.CreatePowershellRunner().Start(new FilePath("Scripts/HashTableTest.ps1"),
+                new PowershellSettings().WithArguments(args => args.AppendHashTable("AHashTable", dict)));
+
+            Assert.True((results != null) && (results.Count == dict.Count + 1));
+            Assert.Equal("0", results[0].BaseObject.ToString());
+
+            foreach (var item in dict.ToArray())
+            {
+                Assert.True(results.Any(r => r.BaseObject.ToString().Equals(($"{item.Key} = {item.Value}"))));
+            }
         }
 
         [Fact]

--- a/src/Cake.Powershell/Arguments/HashTableArgument.cs
+++ b/src/Cake.Powershell/Arguments/HashTableArgument.cs
@@ -1,0 +1,86 @@
+﻿#region Using Statements
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Cake.Core.IO;
+#endregion
+
+
+
+namespace Cake.Powershell
+{
+    /// <summary>
+    /// Represents a hashtable argument.
+    /// </summary>
+    public sealed class HashTableArgument : IProcessArgument
+    {
+        #region Fields
+
+        private const string OpenHashTable = "@{ ";
+        private const string CloseHashTable = " }"; 
+
+        private readonly IEnumerable<IProcessArgument> _arguments;
+        #endregion
+
+
+
+
+
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HashTableArgument"/> class.
+        /// </summary>
+        /// <param name="arguments">The arguments that will be comma separated.</param>
+        public HashTableArgument(IEnumerable<KeyValueArgument> arguments)
+        {
+            _arguments = arguments;
+        }
+        #endregion
+
+
+
+
+
+        #region Methods
+        /// <summary>
+        /// Render the arguments as a <see cref="T:System.String" />.
+        /// Sensitive information will be included.
+        /// </summary>
+        /// <returns>
+        /// A comma separated string representation of the arguments.
+        /// </returns>
+        public string Render()
+        {
+            return ConcatenateStrings(_arguments.Select(argument => argument.Render()));
+        }
+
+        /// <summary>
+        /// Renders the argument as a <see cref="T:System.String" />.
+        /// Sensitive information will be redacted.
+        /// </summary>
+        /// <returns>
+        /// A comma separated safe string representation of the argument.
+        /// </returns>
+        public string RenderSafe()
+        {
+            return ConcatenateStrings(_arguments.Select(argument => argument.RenderSafe()));
+        }
+
+
+
+        private static string ConcatenateStrings(IEnumerable<string> strings)
+        {
+            var stringBuilder = new StringBuilder(OpenHashTable);
+
+            foreach (var s in strings)
+            {
+                stringBuilder.AppendFormat("{0} ", s);
+            }
+
+            stringBuilder.Append(CloseHashTable);
+
+            return stringBuilder.ToString();
+        }
+        #endregion
+    }
+}

--- a/src/Cake.Powershell/Arguments/KeyValueArgument.cs
+++ b/src/Cake.Powershell/Arguments/KeyValueArgument.cs
@@ -1,0 +1,130 @@
+﻿#region Using Statements
+using System;
+using System.Globalization;
+
+using Cake.Core.IO;
+using Cake.Core.IO.Arguments;
+
+#endregion
+
+
+
+namespace Cake.Powershell
+{
+    /// <summary>
+    /// Represents a named argument and its value.
+    /// </summary>
+    public sealed class KeyValueArgument : IProcessArgument
+    {
+        #region Fields
+        private readonly string _Key;
+        private readonly IProcessArgument _Value;
+
+        private string _Format;
+        private const string DefaultFormat = "\"{0}\" = \"{1}\";";
+        #endregion
+
+
+
+
+
+        #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyValueArgument"/> class.
+        /// </summary>
+        /// <param name="key">The key of the argument.</param>
+        /// <param name="value">The value of the argument.</param>
+        public KeyValueArgument(string key, TextArgument value)
+            : this(key, value, KeyValueArgument.DefaultFormat)
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyValueArgument"/> class.
+        /// </summary>
+        /// <param name="key">The key of the argument.</param>
+        /// <param name="value">The argument value.</param>
+        /// <param name="format">The format of argument.</param>
+        public KeyValueArgument(string key, TextArgument value, string format)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (string.IsNullOrEmpty(format))
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+
+            _Key = key;
+            _Value = value;
+            _Format = format;
+        }
+        #endregion
+
+
+
+
+
+        #region Properties
+        /// <summary>
+        /// Gets or sets the format of the argument
+        /// </summary>
+        /// <value>The argument format.</value>
+        public string Format
+        {
+            get
+            {
+                return _Format;
+            }
+
+            set
+            {
+                _Format = value;
+            }
+        }
+        #endregion
+
+
+
+
+
+        #region Methods
+        /// <summary>
+        /// Render the arguments as a <see cref="System.String" />.
+        /// </summary>
+        /// <returns>A string representation of the argument.</returns>
+        public string Render()
+        {
+            return string.Format(CultureInfo.InvariantCulture, _Format, _Key, _Value.Render());
+        }
+
+        /// <summary>
+        /// Renders the argument as a <see cref="System.String"/>.
+        /// Sensitive information will be redacted.
+        /// </summary>
+        /// <returns>A safe string representation of the argument.</returns>
+        public string RenderSafe()
+        {
+            return string.Format(CultureInfo.InvariantCulture, _Format, _Key, _Value.RenderSafe());
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return RenderSafe();
+        }
+        #endregion
+    }
+}

--- a/src/Cake.Powershell/Extensions/ProcessArgumentListExtensions.cs
+++ b/src/Cake.Powershell/Extensions/ProcessArgumentListExtensions.cs
@@ -1,4 +1,6 @@
 ﻿#region Using Statements
+
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -127,6 +129,40 @@ namespace Cake.Powershell
             if (builder != null)
             {
                 builder.Append(new NamedArgument(name, new StringLiteralArgument(argument)));
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Appends the specified arguments as a hashtable to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The argument name.</param>
+        /// <param name="arguments">The dictionary collection to be appended as a hashtable.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendHashTable(this ProcessArgumentBuilder builder, string name, IDictionary<string, string> arguments)
+        {
+            if (builder != null)
+            {
+                builder.Append(new NamedArgument(name, new HashTableArgument(arguments.Select(argument => new KeyValueArgument(argument.Key, new TextArgument(argument.Value))))));
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Appends the specified arguments as a hashtable to the argument builder.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="name">The argument name.</param>
+        /// <param name="arguments">The arguments to be appended as a hashtable.</param>
+        /// <returns>The same <see cref="ProcessArgumentBuilder"/> instance so that multiple calls can be chained.</returns>
+        public static ProcessArgumentBuilder AppendHashTable(this ProcessArgumentBuilder builder, string name, IEnumerable<KeyValueArgument> arguments)
+        {
+            if (builder != null)
+            {
+                builder.Append(new NamedArgument(name, new HashTableArgument(arguments)));
             }
 
             return builder;


### PR DESCRIPTION
  I also adding test cases for Array and HashTable arguments.  If you have any preference on style or conventions you would like changed, let me know.  There's a case for not having the KeyValueArgument class (or having it inherit from NamedArgument) that I put in.  NamedArgument with the constructor overload that passes in the Format can just as easily replace KeyValueArgument, but I decided to make it a separate class, so that each class can have its own identity and not be tethered to purposes other than their original intended purpose.