### PR TITLE
mac/linux support

### DIFF
--- a/src/Cake.Powershell/Aliases/PowershellAliases.cs
+++ b/src/Cake.Powershell/Aliases/PowershellAliases.cs
@@ -30,7 +30,7 @@ namespace Cake.Powershell
         [CakeMethodAlias]
         public static Collection<PSObject> StartPowershellScript(this ICakeContext context, string script)
         {
-            return new PowershellRunner(context.Environment, context.Log).Start(script, new PowershellSettings());
+            return new PowershellRunner(context).Start(script, new PowershellSettings());
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Cake.Powershell
         [CakeMethodAlias]
         public static Collection<PSObject> StartPowershellScript(this ICakeContext context, string script, Action<ProcessArgumentBuilder> arguments)
         {
-            return new PowershellRunner(context.Environment, context.Log).Start(script, new PowershellSettings().WithArguments(arguments));
+            return new PowershellRunner(context).Start(script, new PowershellSettings().WithArguments(arguments));
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Cake.Powershell
         [CakeMethodAlias]
         public static Collection<PSObject> StartPowershellScript(this ICakeContext context, string script, PowershellSettings settings)
         {
-            return new PowershellRunner(context.Environment, context.Log).Start(script, settings);
+            return new PowershellRunner(context).Start(script, settings);
         }
 
 

--- a/src/Cake.Powershell/Runner/PowershellRunner.cs
+++ b/src/Cake.Powershell/Runner/PowershellRunner.cs
@@ -244,7 +244,7 @@ namespace Cake.Powershell
 
             if (_Environment.Platform.Family != PlatformFamily.Windows)
             {
-                var tool = new PwshScriptRunner(_Context.FileSystem, _Context.Environment, _Context.ProcessRunner, _Context.Tools, _Context.Log);
+                var tool = new PwshScriptRunner(_Context.FileSystem, _Context.Environment, _Context.ProcessRunner, _Context.Tools);
                 tool.RunScript(script, settings);
                 return new Collection<PSObject>();
             }

--- a/src/Cake.Powershell/Runner/PowershellRunner.cs
+++ b/src/Cake.Powershell/Runner/PowershellRunner.cs
@@ -6,13 +6,11 @@ using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Net;
-using System.Runtime;
 using System.Threading;
 
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
-using Cake.Core.Tooling;
 using Cake.Powershell.Runner;
 
 #endregion

--- a/src/Cake.Powershell/Runner/PowershellRunner.cs
+++ b/src/Cake.Powershell/Runner/PowershellRunner.cs
@@ -6,11 +6,15 @@ using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Net;
+using System.Runtime;
 using System.Threading;
 
 using Cake.Core;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
+using Cake.Core.Tooling;
+using Cake.Powershell.Runner;
+
 #endregion
 
 
@@ -25,6 +29,7 @@ namespace Cake.Powershell
         #region Fields
         private readonly ICakeEnvironment _Environment;
         private readonly ICakeLog _Log;
+        private readonly ICakeContext _Context;
         private Collection<PSObject> _pipelineResults = new Collection<PSObject>();
 
         private bool _complete;
@@ -33,9 +38,16 @@ namespace Cake.Powershell
         
 
 
-
-
         #region Constructor
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Cake.Powershell.PowershellRunner"/> class.
+        /// </summary>
+        /// <param name="context">Context.</param>
+        public PowershellRunner(ICakeContext context) : this(context.Environment, context.Log) 
+        {
+            _Context = context;
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PowershellRunner" /> class.
         /// </summary>
@@ -229,6 +241,14 @@ namespace Cake.Powershell
         {
             //Create Runspace
             Runspace runspace = null;
+
+            if (_Environment.Platform.Family != PlatformFamily.Windows)
+            {
+                var tool = new PwshScriptRunner(_Context.FileSystem, _Context.Environment, _Context.ProcessRunner, _Context.Tools, _Context.Log);
+                tool.RunScript(script, settings);
+                return new Collection<PSObject>();
+            }
+
 
             if (String.IsNullOrEmpty(settings.ComputerName))
             {

--- a/src/Cake.Powershell/Runner/PwshScriptRunner.cs
+++ b/src/Cake.Powershell/Runner/PwshScriptRunner.cs
@@ -62,7 +62,7 @@ namespace Cake.Powershell.Runner
         /// Builds the arguments for pwsh.
         /// </summary>
         /// <returns>Argument builder containing the arguments based on <paramref name="script"/>.</returns>
-        private ProcessArgumentBuilder GetArguments(string script)
+        private static ProcessArgumentBuilder GetArguments(string script)
         {
             var args = new ProcessArgumentBuilder();
             args.Append(script);

--- a/src/Cake.Powershell/Runner/PwshScriptRunner.cs
+++ b/src/Cake.Powershell/Runner/PwshScriptRunner.cs
@@ -59,7 +59,7 @@ namespace Cake.Powershell.Runner
         }
 
         /// <summary>
-        /// Builds the arguments for npm.
+        /// Builds the arguments for pwsh.
         /// </summary>
         /// <returns>Argument builder containing the arguments based on <paramref name="script"/>.</returns>
         private ProcessArgumentBuilder GetArguments(string script)

--- a/src/Cake.Powershell/Runner/PwshScriptRunner.cs
+++ b/src/Cake.Powershell/Runner/PwshScriptRunner.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.Powershell.Runner
+{
+    public class PwshSettings : ToolSettings
+    {
+
+    }
+
+    /// <summary>
+    /// Runs Pwsh scripts on the command line
+    /// </summary>
+    public class PwshScriptRunner : Tool<PwshSettings>
+    {
+        private readonly ICakeLog _log;
+
+        /// <summary>
+        /// Constructs a PwshScriptRunner
+        /// </summary>
+        public PwshScriptRunner(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools,
+            ICakeLog log) : base(fileSystem, environment, processRunner, tools)
+        {
+            _log = log;
+        }
+
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            return new[] { "pwsh" };
+        }
+
+        protected override string GetToolName()
+        {
+            return "pwsh";
+        }
+
+        public void RunScript(string script, PowershellSettings settings)
+        {
+            var pwshSettings = new PwshSettings
+            {
+                WorkingDirectory = settings.WorkingDirectory,
+                ToolTimeout = settings.Timeout == null ? (TimeSpan?)null : new TimeSpan(0, 0, settings.Timeout.Value)
+            };
+            settings.Arguments.Prepend(script);
+            var args = GetArguments(script, settings);
+            Run(pwshSettings, args);
+        }
+
+        /// <summary>
+        /// Builds the arguments for npm.
+        /// </summary>
+        /// <param name="settings">Settings used for building the arguments.</param>
+        /// <returns>Argument builder containing the arguments based on <paramref name="settings"/>.</returns>
+        protected ProcessArgumentBuilder GetArguments(string script, PowershellSettings settings)
+        {
+
+            var args = new ProcessArgumentBuilder();
+            args.Append(script);
+
+            foreach (var argument in settings.Arguments)
+            {
+                _log.Debug("Maybe append: " + argument);
+            }
+
+            _log.Verbose("pwsh arguments: {0}", args.RenderSafe());
+
+            return args;
+        }
+    }
+}

--- a/src/Cake.Powershell/Runner/PwshScriptRunner.cs
+++ b/src/Cake.Powershell/Runner/PwshScriptRunner.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Cake.Core;
-using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -17,8 +16,6 @@ namespace Cake.Powershell.Runner
     /// </summary>
     public class PwshScriptRunner : Tool<PwshSettings>
     {
-        private readonly ICakeLog _log;
-
         /// <summary>
         /// Constructs a PwshScriptRunner
         /// </summary>
@@ -26,52 +23,49 @@ namespace Cake.Powershell.Runner
             IFileSystem fileSystem,
             ICakeEnvironment environment,
             IProcessRunner processRunner,
-            IToolLocator tools,
-            ICakeLog log) : base(fileSystem, environment, processRunner, tools)
+            IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
         {
-            _log = log;
         }
 
+        /// <summary>Gets the possible names of the tool executable.</summary>
+        /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
             return new[] { "pwsh" };
         }
 
+        /// <summary>Gets the name of the tool.</summary>
+        /// <returns>The name of the tool.</returns>
         protected override string GetToolName()
         {
             return "pwsh";
         }
 
+        /// <summary>
+        /// Runs `pwsh` against the script and settings provided
+        /// </summary>
         public void RunScript(string script, PowershellSettings settings)
         {
             var pwshSettings = new PwshSettings
             {
                 WorkingDirectory = settings.WorkingDirectory,
-                ToolTimeout = settings.Timeout == null ? (TimeSpan?)null : new TimeSpan(0, 0, settings.Timeout.Value)
+                ToolTimeout = settings.Timeout == null
+                    ? (TimeSpan?) null
+                    : new TimeSpan(0, 0, settings.Timeout.Value)
             };
             settings.Arguments.Prepend(script);
-            var args = GetArguments(script, settings);
+            var args = GetArguments(script);
             Run(pwshSettings, args);
         }
 
         /// <summary>
         /// Builds the arguments for npm.
         /// </summary>
-        /// <param name="settings">Settings used for building the arguments.</param>
-        /// <returns>Argument builder containing the arguments based on <paramref name="settings"/>.</returns>
-        protected ProcessArgumentBuilder GetArguments(string script, PowershellSettings settings)
+        /// <returns>Argument builder containing the arguments based on <paramref name="script"/>.</returns>
+        private ProcessArgumentBuilder GetArguments(string script)
         {
-
             var args = new ProcessArgumentBuilder();
             args.Append(script);
-
-            foreach (var argument in settings.Arguments)
-            {
-                _log.Debug("Maybe append: " + argument);
-            }
-
-            _log.Verbose("pwsh arguments: {0}", args.RenderSafe());
-
             return args;
         }
     }


### PR DESCRIPTION
# Summary

Introduces the ability to run powershell scripts on mac and linux per Issue #12.  Supports Arguments and WorkingDirectory.

# Limitations

* Can't run powershell commands, only scripts
* Can't run remote powershell scripts

# To Test

1. Add a script called `hello.ps1` like:

````
Param(
    [parameter(Mandatory=$true)][string]$name
)
Write-Host "Hello $name"
````

2. Run it in a cake script on a Mac or Linux like:

````
StartPowershellScript("hello.ps1", new PowershellSettings {
    Arguments = new ProcessBuilderArguments().Append("-name", "Mr Bob Dobalina")
});
````

Expected: "Hello Mr Bob Dobalina"