### PR TITLE
Enable Dependabot automatic PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/src/Cake.Powershell.Tests/Cake.Powershell.Tests.csproj
+++ b/src/Cake.Powershell.Tests/Cake.Powershell.Tests.csproj
@@ -31,7 +31,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Shouldly" Version="4.2.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="XunitXml.TestLogger" Version="3.0.78" />
     </ItemGroup>
 </Project>

--- a/src/Cake.Powershell.Tests/Cake.Powershell.Tests.csproj
+++ b/src/Cake.Powershell.Tests/Cake.Powershell.Tests.csproj
@@ -30,7 +30,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Shouldly" Version="4.1.0" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="XunitXml.TestLogger" Version="3.0.78" />
     </ItemGroup>

--- a/src/Cake.Powershell.Tests/Cake.Powershell.Tests.csproj
+++ b/src/Cake.Powershell.Tests/Cake.Powershell.Tests.csproj
@@ -26,7 +26,7 @@
 		<PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.3" Condition="'$(TargetFramework)' == 'net7.0'" />
 		
         <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Cake.Powershell.Tests/Cake.Powershell.Tests.csproj
+++ b/src/Cake.Powershell.Tests/Cake.Powershell.Tests.csproj
@@ -22,10 +22,10 @@
         <PackageReference Include="Cake.Core" Version="3.0.0" />
         <PackageReference Include="Cake.Testing" Version="3.0.0" />
 
-	    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.10" Condition="'$(TargetFramework)' == 'net6.0'" />
-		<PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.3" Condition="'$(TargetFramework)' == 'net7.0'" />
+	      <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.10" Condition="'$(TargetFramework)' == 'net6.0'" />
+		    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.3" Condition="'$(TargetFramework)' == 'net7.0'" />
 		
-        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit" Version="2.7.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Enable Dependabot automatic PRs, and then merge the resulting PRs created.

The goal is to create an early warning of security updates.

The current version of Cake.Powershell (version 3.0.0) has an upstream library with a security vulnerability. Dependabot could help lower the administrative load required to close these issues as they come.